### PR TITLE
feat: log query audits to CloudWatch

### DIFF
--- a/blazer/app/models/audit.rb
+++ b/blazer/app/models/audit.rb
@@ -1,0 +1,13 @@
+module Blazer
+  class Audit < Record
+    belongs_to :user, optional: true, class_name: Blazer.user_class.to_s
+    belongs_to :query, optional: true
+    after_save :log_user
+
+    private
+
+    def log_user
+      logger.info "Audit #{user.email} ran '#{query.name}' query: '#{query.statement}'" 
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Update the Audit model to log its audit queries to CloudWatch after they're saved to the `blazer_audits` table.  This will make it simpler to export these audit logs to Sentinel.

This works by overriding the default [Blazer Audit model](https://github.com/ankane/blazer/blob/d53c4513b3fa0e8e83b50a948d1e71cd8f9e9c31/app/models/blazer/audit.rb) with a custom model that registers an `after_save` hook from the ActiveRecord base class.

# Related
- cds-snc/platform-core-services#179