### PR TITLE
fix: switch to JSON logging

### DIFF
--- a/blazer/app/views/blazer/queries/show.html.erb
+++ b/blazer/app/views/blazer/queries/show.html.erb
@@ -1,7 +1,7 @@
 <% blazer_title @query.name %>
 
 <% if @success %>
-  <% run_data = { statement: @query.statement, query_id: @query.id, data_source: @query.data_source, variables: variable_params(@query) } %>
+  <% run_data = {statement: @query.statement, query_id: @query.id, data_source: @query.data_source, variables: variable_params(@query)} %>
   <% run_data.merge!(forecast: "t") if params[:forecast] %>
   <% run_data.merge!(cohort_period: params[:cohort_period]) if params[:cohort_period] %>
   <% run_data.transform_keys!(&:to_s) if Rails::VERSION::MAJOR < 6 %>
@@ -19,6 +19,10 @@
       <div class="col-sm-3 text-right">
         <%= link_to "Edit", edit_query_path(@query, params: variable_params(@query)), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
         <%= link_to "Fork", new_query_path(params: variable_params(@query).merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
+
+        <% if !@error && @success %>
+          <%= button_to "Download", run_queries_path(format: "csv"), params: run_data, class: "btn btn-primary", data: {confirm: "Please confirm there is no protected data before downloading"} %>
+        <% end %>
       </div>
     </div>
   </div>
@@ -40,7 +44,7 @@
   <p><%= @query.description %></p>
 <% end %>
 
-<%= render partial: "blazer/variables", locals: { action: query_path(@query) } %>
+<%= render partial: "blazer/variables", locals: {action: query_path(@query)} %>
 
 <pre id="code"><code><%= @statement.display_statement %></code></pre>
 

--- a/blazer/config/application.rb
+++ b/blazer/config/application.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 Bundler.require
 
+require "json"
 require "rails"
 
 %w[
@@ -47,7 +48,10 @@ module BlazerSolo
 
     if ENV["RAILS_LOG_TO_STDOUT"] != "disabled"
       logger = ActiveSupport::Logger.new($stdout)
-      logger.formatter = config.log_formatter
+      logger.formatter = proc do |severity, datetime, progname, msg|
+        date_format = datetime.strftime("%Y-%m-%d %H:%M:%S %z")
+        JSON.dump(date: date_format.to_s, severity: severity.ljust(5).to_s, message: msg) + "\n"
+      end
       config.logger = ActiveSupport::TaggedLogging.new(logger)
     end
   end


### PR DESCRIPTION
# Summary
Update the log format to JSON so that it can handle newlines in logged data as a single entry.

Also re-enables the `Download` button on queries with a reminder to be careful with data that is downloaded.

# Related
- cds-snc/platform-core-services#179