### PR TITLE
feat: add Docker generate SBOM and vulnerability scan

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 env:
   ECR_SUFFIX: ".dkr.ecr.ca-central-1.amazonaws.com"
@@ -96,3 +96,12 @@ jobs:
       - name: Production ECR logout
         if: steps.changes.outputs.lambda == 'true'
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
+
+      - name: Generate docker SBOM
+        if: steps.changes.outputs.lambda == 'true'
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
+        with:
+          docker_image: "${{ matrix.image }}"
+          dockerfile_path: "${{ matrix.lambda }}/Dockerfile"
+          sbom_name: "${{ matrix.lambda }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"        

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -1,0 +1,60 @@
+name: Docker vulnerability scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  id-token: write
+  security-events: write
+
+env:
+  DOCKER_SLUG: 239043911459.dkr.ecr.ca-central-1.amazonaws.com
+
+jobs:
+  docker-vulnerability-scan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lambda: blazer
+            image: database-tools/blazer
+
+          - lambda: google-cidr
+            image: lambda/google-cidr
+
+          - lambda: heartbeat
+            image: notify/heartbeat
+
+          - lambda: sesemailcallbacks
+            image: notify/ses_to_sqs_email_callbacks
+
+          - lambda: sesreceivingemails
+            image: notify/ses_receiving_emails
+
+          - lambda: snssmscallbacks
+            image: notify/sns_to_sqs_sms_callbacks
+
+    steps:
+      - name: Staging AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-lambdas-apply
+          role-session-name: ECRPush
+          aws-region: ca-central-1
+
+      - name: Staging ECR login
+        id: staging-ecr
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
+
+      - name: Docker vulnerability scan
+        uses: cds-snc/security-tools/.github/actions/docker-scan@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
+        with:
+          docker_image: "${{ env.DOCKER_SLUG }}/${{ matrix.image }}:latest"
+          dockerfile_path: "${{ matrix.lambda }}/Dockerfile"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Staging ECR logout
+        run: docker logout ${{ steps.staging-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary
Add a nightly Docker vulnerability scan and Docker image generate SBOM step.  This will publish security findings and Docker image asset inventories to GitHub.

# Related
- cds-snc/platform-core-services#204