### PR TITLE
fix: bump Docker scan and SBOM action versions

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Generate docker SBOM
         if: steps.changes.outputs.lambda == 'true'
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
         with:
           docker_image: "${{ matrix.image }}"
           dockerfile_path: "${{ matrix.lambda }}/Dockerfile"

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -50,7 +50,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
+        uses: cds-snc/security-tools/.github/actions/docker-scan@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
         with:
           docker_image: "${{ env.DOCKER_SLUG }}/${{ matrix.image }}:latest"
           dockerfile_path: "${{ matrix.lambda }}/Dockerfile"


### PR DESCRIPTION
# Summary
Update the security tools actions to the version which increases the Trivy timeout to 15 minutes.

# Related
- cds-snc/platform-core-services#204
- #25 