### PR TITLE
hook up to notify devcontainer db and fix audit error

### DIFF
--- a/blazer/.env.example
+++ b/blazer/.env.example
@@ -1,5 +1,5 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
-BLAZER_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+DATABASE_URL=postgres://postgres:postgres@localhost:5442/postgres
+BLAZER_DATABASE_URL=postgres://postgres:postgres@localhost:5442/postgres
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 LOG_LEVEL=info

--- a/blazer/README.md
+++ b/blazer/README.md
@@ -7,6 +7,7 @@
     - Authorized JavaScript origins: `http://localhost` and `http://localhost:8080`
     - Authorized redirect URIs: `http://localhost:8080/users/auth/google_oauth2/callback`
 1. Create a `.env` based on the `.env.example` and add your Google OAuth2 credentials.
+1. Edit the `docker-compose.yml` and change the `DATABASE_URL` and `BLAZER_DATABASE_URL` (suggestions are in file)
 1. Run `docker-compose up` and access at [http://localhost:8080](http://localhost:8080).
 1. Connect to the `web` service and run `rails db:migrate`.
 

--- a/blazer/app/models/audit.rb
+++ b/blazer/app/models/audit.rb
@@ -7,7 +7,7 @@ module Blazer
     private
 
     def log_user
-      logger.info "Audit #{user.email} ran '#{query.name}' query: '#{query.statement}'"
+      logger.info "Audit #{user.email} ran query: '#{statement}'"
     end
   end
 end

--- a/blazer/docker-compose.yml
+++ b/blazer/docker-compose.yml
@@ -26,8 +26,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      DATABASE_URL: "postgres://postgres:postgres@host.docker.internal:5442/postgres"
-      BLAZER_DATABASE_URL: "postgresql://postgres:chummy@host.docker.internal:5432/notification_api" # connect to Notify devcontainer db
+      DATABASE_URL: "postgres://postgres:postgres@localhost:5442/postgres"
+      BLAZER_DATABASE_URL: "postgres://postgres:postgres@localhost:5442/postgres"
+      # uncomment to run locally with docker-compose
+      # DATABASE_URL: "postgres://postgres:postgres@host.docker.internal:5442/postgres"
+      # BLAZER_DATABASE_URL: "postgresql://postgres:chummy@host.docker.internal:5432/notification_api"
     depends_on:
       - db
 

--- a/blazer/docker-compose.yml
+++ b/blazer/docker-compose.yml
@@ -9,14 +9,15 @@ services:
       - "postgres"
       - "-c"
       - "listen_addresses=*"
+      - -p 5442
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST_AUTH_METHOD: trust
     expose:
-      - "5432"
+      - "5442"
     ports:
-      - "5432:5432"
+      - "5442:5442"
 
   web:
     build: .
@@ -25,8 +26,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      DATABASE_URL: "postgres://postgres:postgres@db:5432/postgres"
-      BLAZER_DATABASE_URL: "postgres://postgres:postgres@db:5432/postgres"
+      DATABASE_URL: "postgres://postgres:postgres@host.docker.internal:5442/postgres"
+      BLAZER_DATABASE_URL: "postgresql://postgres:chummy@host.docker.internal:5432/notification_api" # connect to Notify devcontainer db
     depends_on:
       - db
 


### PR DESCRIPTION
# Summary | Résumé

In #14 we added Cloudwatch logging to the auditing, however the `query` variable does not exist for running in the edit screen. We can still log the user and what they ran, however.

Also changed `docker-compose.yml` so that it would run and connect to the Notify database running locally in a devcontainer. I don't think this will affect running in staging or production?



# Test instructions | Instructions pour tester la modification

set up an appropriate `.env` and run `docker-compose up`. See the [README](https://github.com/cds-snc/notification-lambdas/blob/main/blazer/README.md) for more details.