### PR TITLE
feat(slack): add slack webhook URL to

### DIFF
--- a/blazer/config/blazer.yml
+++ b/blazer/config/blazer.yml
@@ -56,7 +56,7 @@ audit: true
 # from_email: blazer@example.org
 
 # webhook for Slack
-# slack_webhook_url: <%%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
+slack_webhook_url: <%%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
 
 check_schedules:
   - "1 day"


### PR DESCRIPTION
# Summary | Résumé

This PR adds the slack configuration to blazer and passes an existing slack webhook in from secrets as a test.  Once the functionality is working, we can plumb this properly with a new webhook that we will need to setup.