### PR TITLE
Tweaked connection timeout+max retried for SQS boto

### DIFF
--- a/sesemailcallbacks/ses_to_sqs_email_callbacks.py
+++ b/sesemailcallbacks/ses_to_sqs_email_callbacks.py
@@ -3,9 +3,12 @@ import json
 import boto3
 import uuid
 
+from botocore.client import Config
+
 
 def lambda_handler(event, context):
-    sqs = boto3.resource('sqs')
+    config = Config(connect_timeout=15, retries={'max_attempts': 3})
+    sqs = boto3.resource('sqs', config=config)
     queue = sqs.get_queue_by_name(
         QueueName='eks-notification-canada-cadelivery-receipts'
     )


### PR DESCRIPTION
# Summary | Résumé

We had an incident today where the lambda timeout (1 minute) would kick off before the boto call to SQS timeout (default: 1m).

These changes make the connection timeout to 15 seconds with a max retry strategy of 3. Hence the connection has a total of ~45 seconds to establish a connection. If it gets past this time, the code will timeout prior the lambda running instance itself. This should yield better error message but also more reliability with the lambda as it should retry more than once.

# Test instructions | Instructions pour tester la modification

I'll have to deploy to staging and monitor the situation with a bulk send of emails and their read receipts. 
