### PR TITLE
Add extra logging to system status lambda

### DIFF
--- a/system_status/requirements_for_system_status.txt
+++ b/system_status/requirements_for_system_status.txt
@@ -1,4 +1,4 @@
 requests==2.31.0
 SQLAlchemy==1.4.49
 psycopg2-binary==2.9.7
-git+https://github.com/cds-snc/notifier-utils.git
+git+https://github.com/cds-snc/notifier-utils.git@52.0.18#egg=notifications-utils


### PR DESCRIPTION
# Summary | Résumé

This bumps utils to make use of the extra logging added in [PR#266](https://github.com/cds-snc/notification-utils/pull/266)

# Test instructions | Instructions pour tester la modification
IN STAGING:
- Simulate a site being down by changing one of the site urls to an invalid url
   - [ ] Ensure new log statement is written (`[system_status_site]: site {} is down...`)
- Simulate email/sms sending is down by disabling heartbeat lambda for 5 minutes 
   - [ ] Ensure new log statements are written (`[system_status_email]: email is ...` and `[system_status_sms]: sms is ...`)