### PR TITLE
chore: set logging level explicitly

### DIFF
--- a/system_status/system_status.py
+++ b/system_status/system_status.py
@@ -24,7 +24,8 @@ SQL = ("SELECT      template_id,  AVG(extract(epoch from (n.sent_at - n.created_
         "GROUP BY   template_id ".format(TEMPLATE_IDS))
 
 def handler(event, context):
-    
+    logging.basicConfig(level=logging.INFO)
+
     try:
         # connect to postgres db
         db = sqlalchemy.create_engine(DB_CONN_STRING, future=True)


### PR DESCRIPTION
# Summary | Résumé

Explicitly set the logging level so that INFO logs make it into cloudwatch.