### PR TITLE
temporarily remove pr-bot from workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -131,15 +131,15 @@ jobs:
         if: steps.changes.outputs.lambda == 'true'
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
 
-      - name: my-app-install token
-        id: notify-pr-bot
-        uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6
-        with:
-          app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
-          private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
-        if: ${{ matrix.lambda != 'blazer' }}
+      # - name: my-app-install token
+      #   id: notify-pr-bot
+      #   uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6
+      #   with:
+      #     app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+      #     private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
+      #   if: ${{ matrix.lambda != 'blazer' }}
 
-      - uses: cds-snc/notification-pr-bot@main
-        env:
-          TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
-        if: ${{ matrix.lambda != 'blazer' }}
+      # - uses: cds-snc/notification-pr-bot@main
+      #   env:
+      #     TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
+      #   if: ${{ matrix.lambda != 'blazer' }}


### PR DESCRIPTION
# Summary | Résumé

There's an issue with the docker images not being in ECR but pr-bot wanting to release them. This could lead to a release that breaks heartbeat and the system_status page. Here we comment out the pr-bot part of the action so releases will not make lambda changes. After we've fixed the rest of the workflow we can put pr-bot back in.
