### PR TITLE
chore: update kind and owner

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,11 +1,15 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Resource
 metadata:
   name: notification-lambdas
+  title: Notification Lambdas
   description: Repo that holds all of notify's lambdas
+  annotations:
+    github.com/project-slug: cds-snc/notification-lambdas
   labels:
     license: MIT
 spec:
-  type: website
-  lifecycle: experimental
-  owner: cds-snc
+  type: lambda
+  lifecycle: production
+  owner: group:cds-snc/notify-dev
+  system: gc-notification

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,5 +1,5 @@
 apiVersion: backstage.io/v1alpha1
-kind: Resource
+kind: Component
 metadata:
   name: notification-lambdas
   title: Notification Lambdas
@@ -9,7 +9,7 @@ metadata:
   labels:
     license: MIT
 spec:
-  type: lambda
+  type: service
   lifecycle: production
   owner: group:cds-snc/notify-dev
   system: gc-notification


### PR DESCRIPTION
# Summary | Résumé

Updating the kind of entity to Resource of type lambda, owner to notify-dev team, lifecycle to production.

# Test instructions | Instructions pour tester la modification

Not applicable

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
