### PR TITLE
Fixing Bug 420 -- Notification Lambdas repo

### DIFF
--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -18,7 +18,7 @@ jobs:
           - lambda: google-cidr
             python: 3.9
           - lambda: heartbeat
-            python: 3.10
+            python: "3.10.0"
 
     steps:
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -18,7 +18,7 @@ jobs:
           - lambda: google-cidr
             python: 3.9
           - lambda: heartbeat
-            python: "3.10"
+            python: 3.10
 
     steps:
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -48,7 +48,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
+      - name: Install dependencies
+        if: steps.changes.outputs.lambda == 'true'
+        working-directory: ${{ matrix.lambda }}
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f Gemfile ]; then
+            bundle install
+          else
+            echo "No dependencies to install"
+          fi
       - name: Install deps
         if: steps.changes.outputs.lambda == 'true'
         working-directory: ${{ matrix.lambda }}

--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -48,17 +48,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install dependencies
-        if: steps.changes.outputs.lambda == 'true'
-        working-directory: ${{ matrix.lambda }}
-        run: |
-          if [ -f requirements.txt ]; then
-            pip install -r requirements.txt
-          elif [ -f Gemfile ]; then
-            bundle install
-          else
-            echo "No dependencies to install"
-          fi
+
       - name: Install deps
         if: steps.changes.outputs.lambda == 'true'
         working-directory: ${{ matrix.lambda }}

--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -18,7 +18,7 @@ jobs:
           - lambda: google-cidr
             python: 3.9
           - lambda: heartbeat
-            python: "3.10.0"
+            python: "3.10"
 
     steps:
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -21,6 +21,9 @@ jobs:
             python: "3.10"
 
     steps:
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -8,13 +8,8 @@ fmt:
 	black . $(ARGS)
 
 install:
-    if [ -f requirements.txt ]; then \
-        pip install -r requirements.txt; \
-    elif [ -f Gemfile ]; then \
-        bundle install; \
-    else \
-        echo "No dependencies to install"; \
-    fi
+	pip install --user -r requirements-dev.txt
+	pip install --user -r requirements.txt
 
 lint:
 	pylint heartbeat.py

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -8,8 +8,13 @@ fmt:
 	black . $(ARGS)
 
 install:
-	pip install --user -r requirements-dev.txt \
-	pip install --user -r requirements.txt
+    if [ -f requirements.txt ]; then \
+        pip install -r requirements.txt; \
+    elif [ -f Gemfile ]; then \
+        bundle install; \
+    else \
+        echo "No dependencies to install"; \
+    fi
 
 lint:
 	pylint heartbeat.py

--- a/heartbeat/requirements.txt
+++ b/heartbeat/requirements.txt
@@ -3,5 +3,5 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-notifications-python-client==6.0.2
-git+https://github.com/cds-snc/notifier-utils.git@52.0.17#egg=notifications-utils
+notifications-python-client==10.0.0
+git+https://github.com/cds-snc/notification-utils.git@52.3.3#egg=notifications-utils


### PR DESCRIPTION
# Summary | Résumé

There was a bug in the CI/Actions for the notification lambdas repository. Docker compose wasn't installed so that failed, and also there were issues with the make file when it tried to install some versions.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/420

# Test instructions | Instructions pour tester la modification

CI on the notification lambda repo is working as expected

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
