### PR TITLE
pinning the docker compose action version

### DIFF
--- a/.github/workflows/test-format-lint.yml
+++ b/.github/workflows/test-format-lint.yml
@@ -21,7 +21,7 @@ jobs:
             python: "3.10"
 
     steps:
-      - uses: KengoTODA/actions-setup-docker-compose@main
+      - uses: KengoTODA/actions-setup-docker-compose@d6b647df289e3f2e3db22aeb1d8868a5ae4fce5e # v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
       - name: Checkout


### PR DESCRIPTION
# Summary | Résumé

Just pinning the version for the docker compose Github action

# Test instructions | Instructions pour tester la modification

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
