### PR TITLE
upgrade callbacks to Python 3.12

### DIFF
--- a/pinpointsmscallbacks/Dockerfile
+++ b/pinpointsmscallbacks/Dockerfile
@@ -1,6 +1,6 @@
 # Docker image for the SNS to SQS SMS callback the lambda API.
 
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE 1
 

--- a/sesemailcallbacks/Dockerfile
+++ b/sesemailcallbacks/Dockerfile
@@ -1,6 +1,6 @@
 # Docker image for the SES email callback the lambda API.
 
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE 1
 

--- a/sesreceivingemails/Dockerfile
+++ b/sesreceivingemails/Dockerfile
@@ -1,6 +1,6 @@
 # Docker image for the SES recieving emails hitting the lambda API.
 
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE 1
 

--- a/snssmscallbacks/Dockerfile
+++ b/snssmscallbacks/Dockerfile
@@ -1,6 +1,6 @@
 # Docker image for the SNS to SQS SMS callback the lambda API.
 
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE 1
 


### PR DESCRIPTION
# Summary | Résumé

Upgrade the following lambda functions to Python 3.12:
- `pinpointsmscallbacks`
- `snssmscallbacks`
- `sesemailcallbacks`
- `sesreceivingemails`

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/515

# Test instructions | Instructions pour tester la modification

Verify locally that the images build with:
```
docker build -f pinpointsmscallbacks/Dockerfile .
docker build -f smscallbacks/Dockerfile .
docker build -f snssmscallbacks/Dockerfile .
docker build -f sesemailcallbacks/Dockerfile .
docker build -f sesreceivingemails/Dockerfile .
```

Testing if the functions still actually work will be done in staging.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
