### PR TITLE
add handler parameters to google_cidr

### DIFF
--- a/google-cidr/cidr.py
+++ b/google-cidr/cidr.py
@@ -100,7 +100,7 @@ def get_boto_client(client_type):
     return boto3.client(client_type)
 
 
-def handler():
+def handler(event=None, context=None):
     """Retrieves the list of public Google service CIDR ranges"""
     google_cidrs = get_google_cidrs(IPRANGE_URLS)
 

--- a/google-cidr/cidr.py
+++ b/google-cidr/cidr.py
@@ -100,7 +100,7 @@ def get_boto_client(client_type):
     return boto3.client(client_type)
 
 
-def handler(event=None, context=None):
+def handler(event=None, context=None):  # pylint: disable=unused-argument
     """Retrieves the list of public Google service CIDR ranges"""
     google_cidrs = get_google_cidrs(IPRANGE_URLS)
 


### PR DESCRIPTION
# Summary | Résumé

Getting an error `[ERROR] TypeError: handler() takes 0 positional arguments but 2 were given`. I think we broke it [here](https://github.com/cds-snc/notification-lambdas/commit/10952ad7246a93666ce79622bdd828f24d293cff#diff-8e8ea04a73fe6e8a1c3102bb768db9e8abe4f716f8e1494c28479a03bf7d22e7L100). This PR adds them back.

Note: not upgrading to Python 3.12 yet, just trying to fix first.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/517

# Test instructions | Instructions pour tester la modification

Check logs for errors.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
