### PR TITLE
Add ses_to_sqs_email_callbacks to build & deploy workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -29,6 +29,8 @@ jobs:
             image: notify/heartbeat
           - lambda: system_status
             image: notify/system_status
+          - lambda: sesemailcallbacks
+            image: notify/ses_to_sqs_email_callbacks
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,7 @@ jobs:
           - google-cidr
           - heartbeat
           - system_status
+          - sesemailcallbacks
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `ses_to_sqs_email_callbacks` lambda to the build and build-and-push CI workflows.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

Nothing breaks?

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
