### PR TITLE
Task/prd deploy

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -46,17 +46,26 @@ jobs:
         with:
           filters: |
             lambda:
-              - '${{ matrix.lambda }}/**'
+              - '${{ matrix.folder }}/**'
+              - '.github/workflows/docker-build-and-push.yml'
+            notify_components:
+              - 'heartbeat/**'
+              - 'system_status/**'
+              - 'sesemailcallbacks/**'
               - '.github/workflows/docker-build-and-push.yml'
 
       - name: Build Docker image
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         working-directory: ${{ matrix.folder }}
         run: make docker
 
       # Staging image push
       - name: Staging AWS credentials
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
         with:
           role-to-assume: arn:aws:iam::${{ env.STAGING_ACCOUNT_ID }}:role/notification-lambdas-apply
@@ -64,12 +73,16 @@ jobs:
           aws-region: ca-central-1
 
       - name: Staging ECR login
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         id: staging-ecr
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
       - name: Staging ECR push
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: |
           STAGING_ECR="${{ env.STAGING_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
           docker tag ${{ matrix.image }} $STAGING_ECR/${{ matrix.image }}:${GITHUB_SHA::7}
@@ -78,12 +91,16 @@ jobs:
           docker push $STAGING_ECR/${{ matrix.image }}:latest
 
       - name: Staging ECR logout
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: docker logout ${{ steps.staging-ecr.outputs.registry }}
 
       # Staging Lambda Restart
       - name: Deploy lambda
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: |
           if [[ "${{ matrix.image }}" != "database-tools/blazer" ]]; then
             STAGING_ECR="${{ env.STAGING_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
@@ -93,7 +110,9 @@ jobs:
           fi
 
       - name: Publish lambda version and update alias
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: |
           if [[ "${{ matrix.image }}" != "database-tools/blazer" ]]; then
             aws lambda wait function-updated --function-name ${{ matrix.lambda }}
@@ -104,7 +123,7 @@ jobs:
               --function-version "$VERSION" > /dev/null 2>&1
           fi
 
-      # Production image push - updated condition
+      # Production image push
       - name: Production AWS credentials
         if: |
           steps.changes.outputs.lambda == 'true' ||
@@ -125,7 +144,7 @@ jobs:
       - name: Production ECR push
         if: |
           steps.changes.outputs.lambda == 'true' ||
-          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: |
           PRODUCTION_ECR="${{ env.PRODUCTION_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
           docker tag ${{ matrix.image }} $PRODUCTION_ECR/${{ matrix.image }}:${GITHUB_SHA::7}
@@ -136,7 +155,7 @@ jobs:
       - name: Generate docker SBOM
         if: |
           steps.changes.outputs.lambda == 'true' ||
-          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
@@ -161,7 +180,7 @@ jobs:
           private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
         # Only run pr-bot for non-notify components or if all notify components are built
         if: |
-          ${{ matrix.lambda != 'blazer' &&
+          ${{ matrix.lambda != 'blazer' && 
           (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'ses_to_sqs_email_callbacks') ||
           (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}
 
@@ -170,6 +189,6 @@ jobs:
           TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
         # Only run pr-bot for non-notify components or if all notify components are built
         if: |
-          ${{ matrix.lambda != 'blazer' &&
+          ${{ matrix.lambda != 'blazer' && 
           (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'ses_to_sqs_email_callbacks') ||
           (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,15 +32,10 @@ jobs:
             folder: heartbeat
           - lambda: system_status
             image: notify/system_status
-<<<<<<< HEAD
             folder: system_status
           - lambda: ses_to_sqs_email_callbacks
             image: notify/ses_to_sqs_email_callbacks
             folder: sesemailcallbacks
-=======
-          - lambda: sesemailcallbacks
-            image: notify/ses_to_sqs_email_callbacks
->>>>>>> 7950999 (Push the ses to sqs email callback image and lambda)
 
     steps:
       - name: Checkout
@@ -53,19 +48,13 @@ jobs:
             lambda:
               - '${{ matrix.lambda }}/**'
               - '.github/workflows/docker-build-and-push.yml'
-            notify_components:
-              - 'heartbeat/**'
-              - 'system_status/**'
-              - 'sesemailcallbacks/**'
-              - '.github/workflows/docker-build-and-push.yml'
 
-      # Modified condition to build all notify components if any changes
       - name: Build Docker image
         if: steps.changes.outputs.lambda == 'true'
         working-directory: ${{ matrix.folder }}
         run: make docker
 
-      # Staging image push - updated condition
+      # Staging image push
       - name: Staging AWS credentials
         if: steps.changes.outputs.lambda == 'true'
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
@@ -92,7 +81,7 @@ jobs:
         if: steps.changes.outputs.lambda == 'true'
         run: docker logout ${{ steps.staging-ecr.outputs.registry }}
 
-      # Staging Lambda Restart - updated condition
+      # Staging Lambda Restart
       - name: Deploy lambda
         if: steps.changes.outputs.lambda == 'true'
         run: |
@@ -119,7 +108,7 @@ jobs:
       - name: Production AWS credentials
         if: |
           steps.changes.outputs.lambda == 'true' ||
-          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
         with:
           role-to-assume: arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/notification-lambdas-apply
@@ -129,7 +118,7 @@ jobs:
       - name: Production ECR login
         if: |
           steps.changes.outputs.lambda == 'true' ||
-          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         id: production-ecr
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
@@ -161,7 +150,7 @@ jobs:
       - name: Production ECR logout
         if: |
           steps.changes.outputs.lambda == 'true' ||
-          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'ses_to_sqs_email_callbacks'))
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
 
       - name: my-app-install token
@@ -173,7 +162,7 @@ jobs:
         # Only run pr-bot for non-notify components or if all notify components are built
         if: |
           ${{ matrix.lambda != 'blazer' &&
-          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'sesemailcallbacks') ||
+          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'ses_to_sqs_email_callbacks') ||
           (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}
 
       - uses: cds-snc/notification-pr-bot@main
@@ -182,5 +171,5 @@ jobs:
         # Only run pr-bot for non-notify components or if all notify components are built
         if: |
           ${{ matrix.lambda != 'blazer' &&
-          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'sesemailcallbacks') ||
+          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'ses_to_sqs_email_callbacks') ||
           (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,10 +32,15 @@ jobs:
             folder: heartbeat
           - lambda: system_status
             image: notify/system_status
+<<<<<<< HEAD
             folder: system_status
           - lambda: ses_to_sqs_email_callbacks
             image: notify/ses_to_sqs_email_callbacks
             folder: sesemailcallbacks
+=======
+          - lambda: sesemailcallbacks
+            image: notify/ses_to_sqs_email_callbacks
+>>>>>>> 7950999 (Push the ses to sqs email callback image and lambda)
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -53,13 +53,19 @@ jobs:
             lambda:
               - '${{ matrix.lambda }}/**'
               - '.github/workflows/docker-build-and-push.yml'
+            notify_components:
+              - 'heartbeat/**'
+              - 'system_status/**'
+              - 'sesemailcallbacks/**'
+              - '.github/workflows/docker-build-and-push.yml'
 
+      # Modified condition to build all notify components if any changes
       - name: Build Docker image
         if: steps.changes.outputs.lambda == 'true'
         working-directory: ${{ matrix.folder }}
         run: make docker
 
-      # Staging image push
+      # Staging image push - updated condition
       - name: Staging AWS credentials
         if: steps.changes.outputs.lambda == 'true'
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
@@ -86,7 +92,7 @@ jobs:
         if: steps.changes.outputs.lambda == 'true'
         run: docker logout ${{ steps.staging-ecr.outputs.registry }}
 
-      # Staging Lambda Restart
+      # Staging Lambda Restart - updated condition
       - name: Deploy lambda
         if: steps.changes.outputs.lambda == 'true'
         run: |
@@ -109,9 +115,11 @@ jobs:
               --function-version "$VERSION" > /dev/null 2>&1
           fi
 
-      # Production image push
+      # Production image push - updated condition
       - name: Production AWS credentials
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
         with:
           role-to-assume: arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/notification-lambdas-apply
@@ -119,12 +127,16 @@ jobs:
           aws-region: ca-central-1
 
       - name: Production ECR login
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
         id: production-ecr
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
       - name: Production ECR push
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
         run: |
           PRODUCTION_ECR="${{ env.PRODUCTION_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
           docker tag ${{ matrix.image }} $PRODUCTION_ECR/${{ matrix.image }}:${GITHUB_SHA::7}
@@ -133,7 +145,9 @@ jobs:
           docker push $PRODUCTION_ECR/${{ matrix.image }}:latest
 
       - name: Generate docker SBOM
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
         uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
@@ -145,7 +159,9 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Production ECR logout
-        if: steps.changes.outputs.lambda == 'true'
+        if: |
+          steps.changes.outputs.lambda == 'true' ||
+          (steps.changes.outputs.notify_components == 'true' && (matrix.lambda == 'heartbeat' || matrix.lambda == 'system_status' || matrix.lambda == 'sesemailcallbacks'))
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
 
       - name: my-app-install token
@@ -154,9 +170,17 @@ jobs:
         with:
           app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
           private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
-        if: ${{ matrix.lambda != 'blazer' && steps.changes.outputs.lambda == 'true' }}
+        # Only run pr-bot for non-notify components or if all notify components are built
+        if: |
+          ${{ matrix.lambda != 'blazer' &&
+          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'sesemailcallbacks') ||
+          (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}
 
       - uses: cds-snc/notification-pr-bot@main
         env:
           TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
-        if: ${{ matrix.lambda != 'blazer' && steps.changes.outputs.lambda == 'true' }}
+        # Only run pr-bot for non-notify components or if all notify components are built
+        if: |
+          ${{ matrix.lambda != 'blazer' &&
+          (steps.changes.outputs.lambda == 'true' && matrix.lambda != 'heartbeat' && matrix.lambda != 'system_status' && matrix.lambda != 'sesemailcallbacks') ||
+          (matrix.lambda == 'heartbeat' && steps.changes.outputs.notify_components == 'true') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         include:
           - lambda: blazer
             folder: blazer
@@ -24,14 +23,6 @@ jobs:
             folder: system_status
           - lambda: ses_to_sqs_email_callbacks
             folder: sesemailcallbacks
-=======
-        lambda:
-          - blazer
-          - google-cidr
-          - heartbeat
-          - system_status
-          - sesemailcallbacks
->>>>>>> 7950999 (Push the ses to sqs email callback image and lambda)
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+<<<<<<< HEAD
         include:
           - lambda: blazer
             folder: blazer
@@ -23,6 +24,14 @@ jobs:
             folder: system_status
           - lambda: ses_to_sqs_email_callbacks
             folder: sesemailcallbacks
+=======
+        lambda:
+          - blazer
+          - google-cidr
+          - heartbeat
+          - system_status
+          - sesemailcallbacks
+>>>>>>> 7950999 (Push the ses to sqs email callback image and lambda)
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Summary | Résumé

Update all of the prd docker images if even one docker image changes

Following the description and solution from this card:
```
This is because currently we only build, eg heartbeat if there are changes to the heartbeat code. (same for system_status). So for example, say we change heartbeat and merge. Then the heartbeat image will get built and pushed to staging and prod. This is good. However if we try to get pr-bot to run on heartbeat and system_status, it will think it needs to update the image of BOTH to the head sha of the notification-lambdas repo. This would work for heartbeat in this case, but we haven't built the corresponding image for system_status (since that directory was not changed) and so the pr-bot would make a PR that would hook the system_status lambda up to a non-existing docker image. Which would make system_status fail.

The solution is probably to push images for both whenever the repo changes enough that pr-bot would run, essentially build images for both whenever either changes.
```

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/423

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
