### PR TITLE
Ensure ses callback lambda handles SNS + SQS payload types

### DIFF
--- a/sesemailcallbacks/test_ses_to_sqs_email_callbacks.py
+++ b/sesemailcallbacks/test_ses_to_sqs_email_callbacks.py
@@ -8,7 +8,7 @@ from moto import mock_sqs
 from ses_to_sqs_email_callbacks import lambda_handler  # Import your Lambda function
 
 
-def sns_event(num_records=10):
+def sqs_event(num_records=10):
     """Generate a mock SQS event message with the specified number of records."""
 
     record = {
@@ -22,6 +22,26 @@ def sns_event(num_records=10):
 
     return messages
 
+def sns_event():
+    """Generate a mock SNS event message."""
+    return {
+        "Records": [
+            {
+                "Sns": {
+                    "Message": json.dumps({
+                        "notificationType": "Delivery",
+                        "mail": {
+                            "timestamp": "2025-04-15T15:55:21.620Z",
+                            "messageId": "010d01963a298494-470d5161-a44d-4a3e-9582-e0fa18a886fc-000000"
+                        },
+                        "delivery": {
+                            "timestamp": "2025-04-15T15:55:22.176Z"
+                        }
+                    })
+                }
+            }
+        ]
+    }
 
 def test_lambda_handles_no_records():
 
@@ -29,7 +49,7 @@ def test_lambda_handles_no_records():
 
     # Use mock_sqs as a context manager
     with mock_sqs() as sqs:
-        event = sns_event(0)
+        event = sqs_event(0)
         # Create the queue before calling lambda
         sqs = boto3.resource("sqs", region_name="us-east-1")
         queue = sqs.create_queue(QueueName="eks-notification-canada-cadelivery-receipts")
@@ -51,7 +71,7 @@ def test_lambda_batches_correctly(num_records):
 
     # Use mock_sqs as a context manager
     with mock_sqs() as sqs:
-        event = sns_event(num_records)
+        event = sqs_event(num_records)
         # Create the queue before calling lambda
         sqs = boto3.resource("sqs", region_name="us-east-1")
         queue = sqs.create_queue(QueueName="eks-notification-canada-cadelivery-receipts")
@@ -73,3 +93,22 @@ def test_lambda_batches_correctly(num_records):
             assert "args" in decoded_body
             assert len(json.loads(base64.b64decode(body_content["body"]))["args"][0]["Messages"]) == num_records
 
+
+def test_lambda_handles_sns_path():
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    with mock_sqs():
+        event = sns_event()
+        sqs = boto3.resource("sqs", region_name="us-east-1")
+        queue = sqs.create_queue(QueueName="eks-notification-canada-cadelivery-receipts")
+
+        response = lambda_handler(event, None)
+        assert response["statusCode"] == 200
+
+        messages = queue.receive_messages()
+        # Should send one message per SNS record
+        assert len(messages) == 1
+        for msg in messages:
+            body_content = base64.b64decode(msg.body)
+            decoded_body = json.loads(base64.b64decode(json.loads(body_content)['body']))
+            assert "args" in decoded_body
+            assert "Message" in decoded_body["args"][0]


### PR DESCRIPTION
# Summary | Résumé

This PR ensures that the ses email callback lambda can handle both SQS and SNS messages. This means that we only need to update the TF infrastructure when deploying or reverting batch saving making the process simpler and quicker.

# Test instructions | Instructions pour tester la modification

This code is currently deployed in dev which is running the old SNS topic infrastructure.
## Test with SNS infrastructure
1. Go to dev and send an email. Note that it works correctly and the notification status is updated. 

## Test with SQS infrastructure
1. Check out [this branch containing the SQS infrastructure changes](https://github.com/cds-snc/notification-terraform/tree/revert-1893-revert-1892-revert-1870-revert-1849-task/ses-receipt-buffer-queue): 
2. In Terraform set yourself up the same way you would if you wanted to do a `terragrunt plan`
4. Set your environment to dev `export ENVIRONMENT=dev`
5. Fetch the dev TFvars
6. `cd env/dev/common` and perform a `terragrunt apply`
7. `cd env/dev/ses_to_sqs_email_callbacks` and perform a `terragrunt apply`
8. Send an email again now that the infra is updated to the SQS way of doing things
9. Note successful update of the notification status

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
