### PR TITLE
Fix issue where the PR-Bot is running multiple times

### DIFF
--- a/.github/workflows/create-manifests-release-pr.yml
+++ b/.github/workflows/create-manifests-release-pr.yml
@@ -1,0 +1,34 @@
+name: Create Manifests Release PR
+
+on:
+  workflow_run:
+    workflows: ["Docker image build and push"]
+    branches: [main]
+    types: 
+      - completed
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    # Only run if the triggering workflow (docker build and push) was successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: my-app-install token
+        id: notify-pr-bot
+        uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6
+        with:
+          app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+          private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
+
+      - uses: cds-snc/notification-pr-bot@main
+        env:
+          TOKEN: ${{ steps.notify-pr-bot.outputs.token }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -55,6 +55,7 @@ jobs:
               - 'system_status/**'
               - 'sesemailcallbacks/**'
               - '.github/workflows/docker-build-and-push.yml'
+              - '.github/workflows/create-manifests-release-pr.yml'
 
       - name: Build Docker image
         if: steps.changes.outputs.any_lambda == 'true'
@@ -149,16 +150,3 @@ jobs:
       - name: Production ECR logout
         if: steps.changes.outputs.any_lambda == 'true'
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
-
-      - name: my-app-install token
-        id: notify-pr-bot
-        uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6
-        with:
-          app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
-          private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
-        if: ${{ matrix.lambda != 'blazer' && steps.changes.outputs.any_lambda == 'true' }}
-
-      - uses: cds-snc/notification-pr-bot@main
-        env:
-          TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
-        if: ${{ matrix.lambda != 'blazer' && steps.changes.outputs.any_lambda == 'true' }}


### PR DESCRIPTION
# Summary | Résumé

The PR-bot was running [multiple times](https://github.com/cds-snc/notification-lambdas/actions/runs/15303621411/job/43052568030) when a PR was merged to main because of the matrix strategy used in docker-build-and-push.

This PR moves the pr-bot run out of the docker-build-and-push workflow so that it only runs once after the docker-build-and-push is done. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1896

# Test instructions | Instructions pour tester la modification

After this is merged, the manifests pr should only be created once, after docker-build-and-push completes successfully.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
