### PR TITLE
Rebuild lambdas if any files in the repo change

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -49,13 +49,7 @@ jobs:
               - '${{ matrix.lambda }}/**'
               - '.github/workflows/docker-build-and-push.yml'
             any_lambda:
-              - 'blazer/**'
-              - 'google-cidr/**'
-              - 'heartbeat/**'
-              - 'system_status/**'
-              - 'sesemailcallbacks/**'
-              - '.github/workflows/docker-build-and-push.yml'
-              - '.github/workflows/create-manifests-release-pr.yml'
+              - '**'
 
       - name: Build Docker image
         if: steps.changes.outputs.any_lambda == 'true'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,12 +36,7 @@ jobs:
               - '${{ matrix.lambda }}/**'
               - '.github/workflows/docker-build.yml'
             any_lambda:
-              - 'blazer/**'
-              - 'google-cidr/**'
-              - 'heartbeat/**'
-              - 'system_status/**'
-              - 'sesemailcallbacks/**'
-              - '.github/workflows/docker-build.yml'
+              - '**'
 
       - name: Build Docker image
         if: steps.changes.outputs.any_lambda == 'true'


### PR DESCRIPTION
# Summary | Résumé

Rebuild lambdas if any files in the repo change
This was causing an issue where PR bot was including lambda changes in the release if any file in this repo was changed. But the lambdas were not being built unless a particular set of files changed. 

# Test instructions | Instructions pour tester la modification

Lambda images should be rebuilt whenever any files in the repo change.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
