### PR TITLE
PinpointSMSCallbacks CI in ca-central and us-west-2

### DIFF
--- a/.github/workflows/docker-build-and-push-us-west-2.yml
+++ b/.github/workflows/docker-build-and-push-us-west-2.yml
@@ -1,0 +1,118 @@
+name: Docker image build and push us-west-2
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: write
+
+env:
+  ECR_SUFFIX: ".dkr.ecr.us-west-2.amazonaws.com"
+  STAGING_ACCOUNT_ID: "239043911459"
+  PRODUCTION_ACCOUNT_ID: "296255494825"
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - uses: dorny/paths-filter@7267a8516b6f92bdb098633497bad573efdbf271 # v2.12.0
+        id: changes
+        with:
+          filters: |
+            pinpoint:
+              - 'pinpointsmscallbacks/**'
+              - '.github/workflows/docker-build-and-push-us-west-2.yml'
+
+      - name: Build Docker image
+        if: steps.changes.outputs.pinpoint == 'true'
+        working-directory: pinpointsmscallbacks
+        run: make docker
+
+      - name: Staging AWS credentials
+        if: steps.changes.outputs.pinpoint == 'true'
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.STAGING_ACCOUNT_ID }}:role/notification-lambdas-apply
+          role-session-name: ECRPush
+          aws-region: us-west-2
+
+      - name: Staging ECR login
+        if: steps.changes.outputs.pinpoint == 'true'
+        id: staging-ecr
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
+
+      - name: Staging ECR push
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: |
+          STAGING_ECR="${{ env.STAGING_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
+          docker tag notify/pinpoint_to_sqs_sms_callbacks $STAGING_ECR/notify/pinpoint_to_sqs_sms_callbacks:${GITHUB_SHA::7}
+          docker tag notify/pinpoint_to_sqs_sms_callbacks $STAGING_ECR/notify/pinpoint_to_sqs_sms_callbacks:latest
+          docker push $STAGING_ECR/notify/pinpoint_to_sqs_sms_callbacks:${GITHUB_SHA::7}
+          docker push $STAGING_ECR/notify/pinpoint_to_sqs_sms_callbacks:latest
+
+      - name: Staging ECR logout
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: docker logout ${{ steps.staging-ecr.outputs.registry }}
+
+      - name: Deploy lambda
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: |
+          STAGING_ECR="${{ env.STAGING_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
+          aws lambda update-function-code \
+            --function-name pinpoint_to_sqs_sms_callbacks_us_west_2 \
+            --image-uri $STAGING_ECR/notify/pinpoint_to_sqs_sms_callbacks:${GITHUB_SHA::7} > /dev/null 2>&1
+
+      - name: Publish lambda version and update alias
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: |
+          aws lambda wait function-updated --function-name pinpoint_to_sqs_sms_callbacks_us_west_2
+          VERSION="$(aws lambda publish-version --function-name pinpoint_to_sqs_sms_callbacks_us_west_2 | jq -r '.Version')"
+          aws lambda update-alias \
+            --function-name pinpoint_to_sqs_sms_callbacks_us_west_2 \
+            --name latest \
+            --function-version "$VERSION" > /dev/null 2>&1
+
+      - name: Production AWS credentials
+        if: steps.changes.outputs.pinpoint == 'true'
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/notification-lambdas-apply
+          role-session-name: ECRPush
+          aws-region: us-west-2
+
+      - name: Production ECR login
+        if: steps.changes.outputs.pinpoint == 'true'
+        id: production-ecr
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
+
+      - name: Production ECR push
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: |
+          PRODUCTION_ECR="${{ env.PRODUCTION_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}"
+          docker tag notify/pinpoint_to_sqs_sms_callbacks $PRODUCTION_ECR/notify/pinpoint_to_sqs_sms_callbacks:${GITHUB_SHA::7}
+          docker tag notify/pinpoint_to_sqs_sms_callbacks $PRODUCTION_ECR/notify/pinpoint_to_sqs_sms_callbacks:latest
+          docker push $PRODUCTION_ECR/notify/pinpoint_to_sqs_sms_callbacks:${GITHUB_SHA::7}
+          docker push $PRODUCTION_ECR/notify/pinpoint_to_sqs_sms_callbacks:latest
+
+      - name: Generate docker SBOM
+        if: steps.changes.outputs.pinpoint == 'true'
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
+          TRIVY_JAVA_DB_REPOSITORY: ${{ vars.TRIVY_JAVA_DB_REPOSITORY }}
+        with:
+          docker_image: "${{ env.PRODUCTION_ACCOUNT_ID }}${{ env.ECR_SUFFIX }}/notify/pinpoint_to_sqs_sms_callbacks:latest"
+          dockerfile_path: "pinpointsmscallbacks/Dockerfile"
+          sbom_name: "pinpoint_to_sqs_sms_callbacks-us-west-2"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Production ECR logout
+        if: steps.changes.outputs.pinpoint == 'true'
+        run: docker logout ${{ steps.production-ecr.outputs.registry }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -30,6 +30,9 @@ jobs:
           - lambda: heartbeat
             image: notify/heartbeat
             folder: heartbeat
+          - lambda: pinpoint_to_sqs_sms_callbacks
+            image: notify/pinpoint_to_sqs_sms_callbacks
+            folder: pinpointsmscallbacks
           - lambda: system_status
             image: notify/system_status
             folder: system_status
@@ -131,7 +134,7 @@ jobs:
 
       - name: Generate docker SBOM
         if: steps.changes.outputs.any_lambda == 'true'
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
           TRIVY_JAVA_DB_REPOSITORY: ${{ vars.TRIVY_JAVA_DB_REPOSITORY }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,8 @@ jobs:
             folder: google-cidr
           - lambda: heartbeat
             folder: heartbeat
+          - lambda: pinpoint_to_sqs_sms_callbacks
+            folder: pinpointsmscallbacks
           - lambda: system_status
             folder: system_status
           - lambda: ses_to_sqs_email_callbacks


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces support for building, pushing, and deploying the `pinpoint_to_sqs_sms_callbacks` lambda Docker image in the `us-west-2` AWS region, and updates related workflows to include this lambda. It also upgrades the SBOM (Software Bill of Materials) generation action to a newer version for improved security tooling.

**Support for new Lambda and region:**

- Added a new GitHub Actions workflow `.github/workflows/docker-build-and-push-us-west-2.yml` to build, push, and deploy the `pinpoint_to_sqs_sms_callbacks` Docker image to both staging and production ECR repositories in the `us-west-2` AWS region, including lambda deployment and alias management.
- Updated `.github/workflows/docker-build-and-push.yml` and `.github/workflows/docker-build.yml` to include `pinpoint_to_sqs_sms_callbacks` in the list of managed lambdas, ensuring it is built and processed by the main Docker workflows. [[1]](diffhunk://#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5R33-R35) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R22-R23)

**Security and tooling improvements:**

- Upgraded the SBOM generation action in `.github/workflows/docker-build-and-push.yml` from v3.2.0 to v4.0.1 for enhanced security and compatibility.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
