### PR TITLE
Add new lambda to receive file scan verdicts

### DIFF
--- a/file-scan-verdict-callbacks/Dockerfile
+++ b/file-scan-verdict-callbacks/Dockerfile
@@ -1,0 +1,12 @@
+# Docker image for the SES email callback the lambda API.
+FROM public.ecr.aws/lambda/python:3.12
+ENV PYTHONDONTWRITEBYTECODE 1
+
+# Install the function's dependencies
+COPY requirements_for_file_scan_verdict_callbacks.txt ${LAMBDA_TASK_ROOT}
+RUN python -m pip install -r requirements_for_file_scan_verdict_callbacks.txt
+
+# Copy function code
+COPY file_scan_verdict_callbacks.py ${LAMBDA_TASK_ROOT}
+
+CMD [ "file_scan_verdict_callbacks.lambda_handler" ]

--- a/file-scan-verdict-callbacks/Makefile
+++ b/file-scan-verdict-callbacks/Makefile
@@ -1,0 +1,23 @@
+docker:
+	docker build -t notify/ses_to_sqs_email_callbacks .
+
+fmt:
+	black . $(ARGS)
+
+install:
+	pip install --user -r requirements_for_file_scan_verdict_callbacks.txt
+	pip install --user -r requirements-dev.txt
+
+lint:
+	pylint ses_to_sqs_email_callbacks.py
+
+test:
+	python3 -m pytest -s -vv test_file_scan_verdict_callbacks.py
+
+.PHONY: \
+	docker \
+	fmt \
+	install \
+	lint \
+	test
+	

--- a/file-scan-verdict-callbacks/file_scan_verdict_callbacks.py
+++ b/file-scan-verdict-callbacks/file_scan_verdict_callbacks.py
@@ -46,10 +46,11 @@ def lambda_handler(event, context):
         return {"status": "skipped", "reason": "unparseable_key"}
 
     service_id = m.group("service_id")
-    file_id = m.group("document_id")
+    document_id = m.group("document_id")
     new_status = STATUS_MAP.get(scan_result, "virus_scan_failed")
 
-    url = f"{NOTIFY_API_BASE_URL}/service/{service_id}/files/{file_id}/status"
+    # Update url once the auth + endpoint routes are implemented
+    url = f"{NOTIFY_API_BASE_URL}/template/files/{document_id}/status"
     headers = {
         "Authorization": f"Bearer {SCAN_CALLBACK_SECRET}",
         "Content-Type": "application/json",
@@ -59,8 +60,8 @@ def lambda_handler(event, context):
     resp = requests.post(url, json=payload, headers=headers, timeout=10)
 
     if resp.status_code == 200:
-        print(f"Updated file {file_id} to status={new_status}")
-        return {"status": "ok", "file_id": file_id, "new_status": new_status}
+        print(f"Updated file {document_id} to status={new_status}")
+        return {"status": "ok", "document_id": document_id, "new_status": new_status}
 
     print(f"API returned {resp.status_code}: {resp.text}")
     resp.raise_for_status()  # triggers Lambda retry / DLQ

--- a/file-scan-verdict-callbacks/file_scan_verdict_callbacks.py
+++ b/file-scan-verdict-callbacks/file_scan_verdict_callbacks.py
@@ -1,0 +1,66 @@
+import json
+import os
+import re
+import time
+
+import boto3
+import requests
+
+SCAN_CALLBACK_SECRET = os.environ["SCAN_CALLBACK_SECRET"]
+NOTIFY_API_BASE_URL = os.environ["NOTIFY_API_URL"]
+
+# Object key pattern: template/<service_id>/<document_id>
+KEY_RE = re.compile(
+    r"^template/(?P<service_id>[0-9a-f-]{36})/(?P<document_id>[0-9a-f-]{36})$"
+)
+
+STATUS_MAP = {
+    "NO_THREATS_FOUND": "uploaded",
+    "THREATS_FOUND": "virus_scan_failed",
+    # Leave scan errors terminal so UI can show failure rather than spin forever
+    "UNSUPPORTED": "virus_scan_failed",
+    "ACCESS_DENIED": "virus_scan_failed",
+    "FAILED": "virus_scan_failed",
+}
+
+
+def lambda_handler(event, context):
+    detail = event["detail"]
+    scan_status = detail.get("scanStatus")
+    scan_result = detail.get("scanResultDetails", {}).get("scanResultStatus")
+    object_key = detail["s3ObjectDetails"]["objectKey"]
+    bucket_name = detail["s3ObjectDetails"]["bucketName"]
+
+    print(
+        f"Scan result: bucket={bucket_name} key={object_key} "
+        f"scanStatus={scan_status} scanResult={scan_result}"
+    )
+
+    if scan_status != "COMPLETED":
+        print(f"Scan not completed (status={scan_status}), skipping.")
+        return {"status": "skipped", "reason": "scan_not_completed"}
+
+    m = KEY_RE.match(object_key)
+    if not m:
+        print(f"Cannot parse service_id/document_id from key: {object_key}")
+        return {"status": "skipped", "reason": "unparseable_key"}
+
+    service_id = m.group("service_id")
+    file_id = m.group("document_id")
+    new_status = STATUS_MAP.get(scan_result, "virus_scan_failed")
+
+    url = f"{NOTIFY_API_BASE_URL}/service/{service_id}/files/{file_id}/status"
+    headers = {
+        "Authorization": f"Bearer {SCAN_CALLBACK_SECRET}",
+        "Content-Type": "application/json",
+    }
+    payload = {"status": new_status}
+
+    resp = requests.post(url, json=payload, headers=headers, timeout=10)
+
+    if resp.status_code == 200:
+        print(f"Updated file {file_id} to status={new_status}")
+        return {"status": "ok", "file_id": file_id, "new_status": new_status}
+
+    print(f"API returned {resp.status_code}: {resp.text}")
+    resp.raise_for_status()  # triggers Lambda retry / DLQ

--- a/file-scan-verdict-callbacks/requirements_for_file_scan_verdict_callbacks.txt
+++ b/file-scan-verdict-callbacks/requirements_for_file_scan_verdict_callbacks.txt
@@ -1,0 +1,5 @@
+boto3==1.26.23
+black==24.4.2
+pytest==8.2.0
+pytest-mock==3.8.0
+requests==2.31.0

--- a/file-scan-verdict-callbacks/test_file_scan_verdict_callbacks.py
+++ b/file-scan-verdict-callbacks/test_file_scan_verdict_callbacks.py
@@ -1,0 +1,144 @@
+import importlib
+import sys
+
+
+MODULE_NAME = "file_scan_verdict_callbacks"
+
+
+def _load_module(monkeypatch):
+    monkeypatch.setenv("SCAN_CALLBACK_SECRET", "test-secret")
+    monkeypatch.setenv("NOTIFY_API_URL", "https://notify.example.com")
+
+    if MODULE_NAME in sys.modules:
+        return importlib.reload(sys.modules[MODULE_NAME])
+
+    return importlib.import_module(MODULE_NAME)
+
+
+# Based on the payload described in docs:
+# https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_eventbridge.html#guardduty_findings_eventbridge_format
+def _guardduty_event(scan_status, scan_result_status, object_key):
+    return {
+        "detail": {
+            "schemaVersion": "1.0",
+            "scanStatus": scan_status,
+            "resourceType": "S3_OBJECT",
+            "s3ObjectDetails": {
+                "bucketName": "amzn-s3-demo-bucket",
+                "objectKey": object_key,
+                "eTag": "etag-value",
+                "versionId": "version-id",
+                "s3Throttled": False,
+            },
+            "scanResultDetails": {
+                "scanResultStatus": scan_result_status,
+                "threats": None,
+                "statusReasons": None,
+            },
+        }
+    }
+
+
+class _Response:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+
+def test_lambda_handler_parses_no_threats_payload(monkeypatch):
+    module = _load_module(monkeypatch)
+    service_id = "11111111-1111-1111-1111-111111111111"
+    file_id = "22222222-2222-2222-2222-222222222222"
+    object_key = f"template/{service_id}/{file_id}"
+    event = _guardduty_event("COMPLETED", "NO_THREATS_FOUND", object_key)
+
+    captured = {}
+
+    def _fake_post(url, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response(status_code=200)
+
+    monkeypatch.setattr(module.requests, "post", _fake_post)
+
+    result = module.lambda_handler(event, None)
+
+    assert result == {"status": "ok", "file_id": file_id, "new_status": "uploaded"}
+    assert (
+        captured["url"]
+        == f"https://notify.example.com/service/{service_id}/files/{file_id}/status"
+    )
+    assert captured["json"] == {"status": "uploaded"}
+    assert captured["headers"]["Authorization"] == "Bearer test-secret"
+    assert captured["timeout"] == 10
+
+
+def test_lambda_handler_parses_threats_found_payload(monkeypatch):
+    module = _load_module(monkeypatch)
+    service_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    file_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    object_key = f"template/{service_id}/{file_id}"
+    event = _guardduty_event("COMPLETED", "THREATS_FOUND", object_key)
+
+    captured = {}
+
+    def _fake_post(url, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response(status_code=200)
+
+    monkeypatch.setattr(module.requests, "post", _fake_post)
+
+    result = module.lambda_handler(event, None)
+
+    assert result == {
+        "status": "ok",
+        "file_id": file_id,
+        "new_status": "virus_scan_failed",
+    }
+    assert (
+        captured["url"]
+        == f"https://notify.example.com/service/{service_id}/files/{file_id}/status"
+    )
+    assert captured["json"] == {"status": "virus_scan_failed"}
+
+
+def test_lambda_handler_skips_non_completed_scan(monkeypatch):
+    module = _load_module(monkeypatch)
+    event = _guardduty_event(
+        "SKIPPED",
+        "UNSUPPORTED",
+        "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+    )
+
+    def _unexpected_post(*args, **kwargs):
+        raise AssertionError(
+            "requests.post should not be called when scanStatus != COMPLETED"
+        )
+
+    monkeypatch.setattr(module.requests, "post", _unexpected_post)
+
+    result = module.lambda_handler(event, None)
+
+    assert result == {"status": "skipped", "reason": "scan_not_completed"}
+
+
+def test_lambda_handler_skips_unparseable_object_key(monkeypatch):
+    module = _load_module(monkeypatch)
+    event = _guardduty_event("COMPLETED", "NO_THREATS_FOUND", "not/a/valid/key")
+
+    def _unexpected_post(*args, **kwargs):
+        raise AssertionError("requests.post should not be called for unparseable key")
+
+    monkeypatch.setattr(module.requests, "post", _unexpected_post)
+
+    result = module.lambda_handler(event, None)
+
+    assert result == {"status": "skipped", "reason": "unparseable_key"}

--- a/file-scan-verdict-callbacks/test_file_scan_verdict_callbacks.py
+++ b/file-scan-verdict-callbacks/test_file_scan_verdict_callbacks.py
@@ -51,8 +51,8 @@ class _Response:
 def test_lambda_handler_parses_no_threats_payload(monkeypatch):
     module = _load_module(monkeypatch)
     service_id = "11111111-1111-1111-1111-111111111111"
-    file_id = "22222222-2222-2222-2222-222222222222"
-    object_key = f"template/{service_id}/{file_id}"
+    document_id = "22222222-2222-2222-2222-222222222222"
+    object_key = f"template/{service_id}/{document_id}"
     event = _guardduty_event("COMPLETED", "NO_THREATS_FOUND", object_key)
 
     captured = {}
@@ -68,10 +68,10 @@ def test_lambda_handler_parses_no_threats_payload(monkeypatch):
 
     result = module.lambda_handler(event, None)
 
-    assert result == {"status": "ok", "file_id": file_id, "new_status": "uploaded"}
+    assert result == {"status": "ok", "document_id": document_id, "new_status": "uploaded"}
     assert (
         captured["url"]
-        == f"https://notify.example.com/service/{service_id}/files/{file_id}/status"
+        == f"https://notify.example.com/template/files/{document_id}/status"
     )
     assert captured["json"] == {"status": "uploaded"}
     assert captured["headers"]["Authorization"] == "Bearer test-secret"
@@ -81,8 +81,8 @@ def test_lambda_handler_parses_no_threats_payload(monkeypatch):
 def test_lambda_handler_parses_threats_found_payload(monkeypatch):
     module = _load_module(monkeypatch)
     service_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    file_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-    object_key = f"template/{service_id}/{file_id}"
+    document_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    object_key = f"template/{service_id}/{document_id}"
     event = _guardduty_event("COMPLETED", "THREATS_FOUND", object_key)
 
     captured = {}
@@ -100,12 +100,12 @@ def test_lambda_handler_parses_threats_found_payload(monkeypatch):
 
     assert result == {
         "status": "ok",
-        "file_id": file_id,
+        "document_id": document_id,
         "new_status": "virus_scan_failed",
     }
     assert (
         captured["url"]
-        == f"https://notify.example.com/service/{service_id}/files/{file_id}/status"
+        == f"https://notify.example.com/template/files/{document_id}/status"
     )
     assert captured["json"] == {"status": "virus_scan_failed"}
 


### PR DESCRIPTION
# Summary | Résumé
This PR adds a new lambda `file-scan-verdict-callbacks` that receives GuardDuty scan result payloads to enable updating template file status updates in the DB in a timely manner. The handler:
1. Receives the GuardDuty scan result payload via an EventBridge event
2. Parses the event extracting the:
    - `service_id` that the file belongs to and the S3 `document_id`
    - `scanResultStatus` and maps it to the corresponding "notify" scan status type
3. Calls the API to update the status in the DB

## Related Issues | Cartes liées

* https://docs.google.com/document/d/1y6ewfFY88CMJZNr715KS1SZwmZrOV4xdpsgCd7lNo4Q/edit?tab=t.0

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] The `Dockerfile` builds

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
