### PR TITLE
Restrict Blazer checks to a dedicated checks datasource

### DIFF
--- a/blazer/README.md
+++ b/blazer/README.md
@@ -14,6 +14,8 @@
 All routes are protected by Devise, so will need to sign in with Google to access Blazer.  Users that are already signed into their Google account will be automatically signed in once they've accepted the consent screen.
 
 ## Notes
+Checks use query data sources. This app includes a dedicated `checks` data source, and checks can only be created for queries that use it. Configure `BLAZER_CHECKS_DATABASE_URL` with a restricted read-only database user for tables allowed in checks. Optionally set `BLAZER_CHECKS_DATA_SOURCE_NAME` if you use a different data source name.
+
 To remove Google Sign-in and use server-side sign-in:
 
 1. Add `gem "omniauth-rails_csrf_protection"` to the [`Gemfile`](./Gemfile).

--- a/blazer/config/blazer.yml
+++ b/blazer/config/blazer.yml
@@ -4,6 +4,9 @@ data_sources:
   main:
     url: <%= ENV["BLAZER_DATABASE_URL"] || ENV["DATABASE_URL"] %>
 
+  checks:
+    url: <%= ENV["BLAZER_CHECKS_DATABASE_URL"] %>
+
     # statement timeout, in seconds
     # none by default
     # timeout: 15

--- a/blazer/config/initializers/blazer_check_source_guard.rb
+++ b/blazer/config/initializers/blazer_check_source_guard.rb
@@ -1,0 +1,37 @@
+# Restrict checks to queries that use the dedicated checks data source.
+Rails.application.config.to_prepare do
+  checks_data_source = ENV.fetch("BLAZER_CHECKS_DATA_SOURCE_NAME", "checks")
+
+  next if Blazer::Check.method_defined?(:query_must_use_checks_data_source)
+
+  Blazer::Check.class_eval do
+    validate :query_must_use_checks_data_source
+
+    private
+
+    def query_must_use_checks_data_source
+      return if query.blank?
+      checks_data_source = ENV.fetch("BLAZER_CHECKS_DATA_SOURCE_NAME", "checks")
+      return if query.data_source == checks_data_source
+
+      errors.add(:base, "Checks can only be created for queries using the #{checks_data_source} data source")
+    end
+  end
+
+  module ::BlazerChecksDataSourceGuard
+    def run_checks(schedule: nil)
+      checks_data_source = ENV.fetch("BLAZER_CHECKS_DATA_SOURCE_NAME", "checks")
+
+      checks = Blazer::Check.includes(:query).joins(:query).where(blazer_queries: {data_source: checks_data_source})
+      checks = checks.where(schedule: schedule) if schedule
+
+      checks.find_each do |check|
+        next if check.state == "disabled"
+
+        Safely.safely { run_check(check) }
+      end
+    end
+  end
+
+  Blazer.singleton_class.prepend(BlazerChecksDataSourceGuard) unless Blazer.singleton_class < BlazerChecksDataSourceGuard
+end


### PR DESCRIPTION
## Summary
This change introduces a dedicated checks datasource in Blazer and enforces that checks are only created and executed for queries using that datasource.

## Why
We want normal Blazer querying to remain broad, while limiting checks to a restricted DB user/table scope.

## Changes
1. Added a dedicated checks datasource configuration:
`blazer.yml:7`

2. Added runtime/app guards for checks:
`blazer_check_source_guard.rb:1`
- Validates check create/update so checks can only target queries on the checks datasource.
- Overrides scheduled check execution to run only checks whose query datasource matches the checks datasource.

3. Documented required configuration and behavior:
`README.md:17`

## Behavior after this PR
1. Queries can still run on any configured datasource.
2. Checks can only be created for queries on the checks datasource.
3. Scheduled run_checks only executes checks tied to that datasource.
4. Datasource name is configurable with BLAZER_CHECKS_DATA_SOURCE_NAME (default: checks).

Configuration required
1. Set BLAZER_CHECKS_DATABASE_URL to a restricted read-only DB user (restricted table/view access).
2. Optionally set BLAZER_CHECKS_DATA_SOURCE_NAME if you do not want to use checks as the datasource name.

Testing
1. Start Blazer with BLAZER_CHECKS_DATABASE_URL set.
2. Create a query on main datasource and attempt to create a check: should fail with validation message.
3. Create a query on checks datasource and create a check: should succeed.
4. Run scheduled checks manually with rake blazer:run_checks SCHEDULE="5 minutes" and verify only checks-datasource checks are executed.

Notes
1. No database migrations were added.
2. This PR is app-level enforcement; infra wiring for the new env var is handled in notification-terraform.