### PR TITLE
feat: Add repository_dispatch to notify manifests of Lambda tag updates

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -147,3 +147,21 @@ jobs:
       - name: Production ECR logout
         if: steps.changes.outputs.any_lambda == 'true'
         run: docker logout ${{ steps.production-ecr.outputs.registry }}
+
+      - name: Notify manifests of Lambda image tag update
+        if: steps.changes.outputs.any_lambda == 'true' && !contains(fromJson('["blazer", "google-cidr"]'), matrix.lambda)
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const shortSha = '${{ github.sha }}'.substring(0, 7);
+            await github.rest.repos.createDispatchEvent({
+              owner: 'cds-snc',
+              repo: 'notification-manifests',
+              event_type: 'update-docker-image',
+              client_payload: {
+                component: '${{ matrix.lambda }}',
+                docker_tag: shortSha
+              }
+            });
+            console.log(`Dispatched update-docker-image for ${{ matrix.lambda }}:${shortSha}`)


### PR DESCRIPTION
## Summary

Add automated notification to notification-manifests repo when Lambda images are pushed to ECR. This enables tag tracking in helmfile using the same `repository_dispatch` mechanism as notify-api and notify-admin.

## Changes

- Add new step "Notify manifests of Lambda image tag update" to `docker-build-and-push.yml`
- Fires after successful image push to ECR (both staging and production accounts)
- Sends `repository_dispatch` event to notification-manifests with:
  - event_type: `update-docker-image`
  - component: `HEARTBEAT`, `SYSTEM_STATUS`, or `SES_TO_SQS_EMAIL_CALLBACKS`
  - docker_tag: 7-char short commit SHA

## Why

**Current state**: Lambda image tags are hardcoded in `notification-manifests/.github/workflows/helmfile_production_apply.yaml`, making them difficult to track and version.

**New state**: When a Lambda builds and pushes to ECR, it automatically triggers manifests to update the tag env vars (`HEARTBEAT_DOCKER_TAG`, etc.), following the exact same pattern as api/admin component builds.

## Filters

- Only fires for the three Notify app Lambdas: heartbeat, system_status, ses_to_sqs_email_callbacks
- Skips infrastructure lambdas: blazer, google-cidr (they don't need manifests tracking)

## Dependency

This PR depends on notification-manifests PR #5141 being merged first. That PR adds the env vars to .env files and documents the workflow.

## Testing

After both PRs merge:
1. Make a test push to notification-lambdas/main
2. Verify the dispatch event fires (check Actions tab)
3. Verify notification-manifests receives the dispatch and updates staging.env automatically
4. CI should pass (helmfile-diff validates the tag exists)